### PR TITLE
#30 Fix laravel's queue worker starting before chromedriver

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: heroku-php-apache2 public/
-worker: trap '' SIGTERM; chromedriver & php artisan queue:work & wait -n; kill -SIGTERM -$$; wait
+worker: trap '' SIGTERM; chromedriver & (wait 10 && php artisan queue:work) & wait -n; kill -SIGTERM -$$; wait


### PR DESCRIPTION
See #30 

Resolving the issue by sleeping for 10 seconds before launching the queue worker to give time for chromedriver to start.